### PR TITLE
Add f-string support

### DIFF
--- a/syntaxes/highlight-sql-string.json
+++ b/syntaxes/highlight-sql-string.json
@@ -1,24 +1,23 @@
 {
-    "fileTypes": [
-      "py"
-    ],
-    "injectionSelector": "L:string.quoted.multi",
-    "patterns": [
-      {
-        "begin": "(--sql|--beginsql|--begin-sql)",
-        "end": "(;|--endsql|--end-sql)",
-        "captures": {
-          "1": {
-            "name": "variable.parameter"
-          }
-        },
-        "patterns": [
-          {
-            "include": "source.sql"
-          }
-        ]
-      }
-    ],
-    "scopeName": "python-sql.injection"
+  "fileTypes": [
+    "py"
+  ],
+  "injectionSelector": "L:string.quoted.multi.python, L:meta.fstring.python - (comment.line.number-sign.python, punctuation.definition.comment.python)",
+  "patterns": [
+    {
+      "begin": "(--sql|--beginsql|--begin-sql)",
+      "end": "(;|--endsql|--end-sql)",
+      "captures": {
+        "1": {
+          "name": "variable.parameter"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.sql"
+        }
+      ]
+    }
+  ],
+  "scopeName": "python-sql.injection"
 }
-  


### PR DESCRIPTION
This adds 'basic' support for `f-strings`.

With this commit `python-string-sql` will be able to highlight the following code :

```python
mytable = "table123"

query = f"""--sql
    SELECT * from {mytable};
"""
```

Cheers! :-)

PS: I just noticed that there is a little indentation mismatch. I think it was a mix of `4 space` and `2 space` before. My auto-formatter changed it to `2 space` only. The only line that really changed is `line 5`.