### PR TITLE
Adding support for mySQL

### DIFF
--- a/syntaxes/highlight-sql-string.json
+++ b/syntaxes/highlight-sql-string.json
@@ -5,8 +5,8 @@
   "injectionSelector": "L:string.quoted.multi.python, L:meta.fstring.python - (comment.line.number-sign.python, punctuation.definition.comment.python)",
   "patterns": [
     {
-      "begin": "( *--sql| *--beginsql| *--begin-sql)",
-      "end": "( *;| *--endsql| *--end-sql)",
+      "begin": "( *--sql| *--beginsql| *--begin-sql| *-- sql| *-- beginsql| *-- begin-sql)",
+      "end": "( *;| *--endsql| *--end-sql| * ;| *-- endsql| *-- end-sql)",
       "captures": {
         "1": {
           "name": "variable.parameter"


### PR DESCRIPTION
mySQL queries will fail with the '--sql' tag on top, because mySQL comments requires at least one space between the double dash and text after '-- sql', so added this as well.